### PR TITLE
Update markdown.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,6 @@
-# Jasmine Markdown Reporter
+# Jasmine Markdown Reporter Green Apple 
 
+A fork of JMP [https://github.com/binodnp/jasmine-markdown-reporter] but with emojis added to the markdown.js so that github can view it. (In the origial JMP they used external url for images)
+
+... 
 Generates jasmine test report as a single document that can live in your project. Uses Github-flavored markdown.
-
-## Quickstart
-
-```
-npm install jasmine-markdown-reporter --save-dev
-```
-
-```javascript
-const path = require('path')
-const MarkdownReporter = require('jasmine-markdown-reporter')
-
-global.jasmine.getEnv().clearReporters()
-// add other reporters
-
-global.jasmine.getEnv().addReporter(new MarkdownReporter({
-  title: 'Jasmine Test Results',
-  destination: path.join(process.cwd(), 'spec.md'),
-  // mode: 'markdown' // 'html' or 'markdown'
-}))
-```
-
-and then run
-
-```
-jasmine
-```
-
-
-produces a report `spec.md` on your project root directory which looks something like this
-
-![Jasmine Markdown Reporter](./static/markdown-reporter.png)
-
-## Passing Tests
-
-look like this
-
-![Passing Test](static/passing-tests.png)
-
-
-## Test Summary
-
-looks like this
-
-![Summary](./static/summary.png)
-

--- a/generators/markdown.js
+++ b/generators/markdown.js
@@ -17,8 +17,8 @@ limitations under the License.
 const fs = require('fs').promises
 const literals = require('../literals/en.json')
 
-const passedFlag = `![${literals.passed}](https://via.placeholder.com/12/0dd969/000000?text=+)`
-const failedFlag = `![${literals.failed}](https://via.placeholder.com/12/f54977/000000?text=+)`
+const passedFlag = `![${literals.passed}]✔️`
+const failedFlag = `![${literals.failed}]❌`
 const failedImage = `<img alt="${literals.failed}" src="https://via.placeholder.com/12/f54977/000000?text=+" style="max-width:100%;">`
 
 class Generator {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jasmine-markdown-reporter",
+  "name": "jasmine-md-reporter-green-apple",
   "version": "1.0.1",
   "description": "Jasmine Markdown Reporter",
   "main": "index.js",


### PR DESCRIPTION
added emojis instead of external url. 
(This way we could show the markdown in github)
[https://stackoverflow.com/questions/11915826/image-not-showing-up-in-readme-md-on-github](https://stackoverflow.com/questions/11915826/image-not-showing-up-in-readme-md-on-github)